### PR TITLE
Fix resolver markers

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nox-3-${{ matrix.python-version }}-
     - run: pip install nox poetry
-    - run: nox --report nox-report.json
+    - run: nox --no-error-on-missing-interpreters --report nox-report.json
 
     services:
       postgres:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 # Hidden root files: tools, IDEs, etc
 /.*
+!/.github
 
 # ===[ PYTHON ]=== #
 __pycache__

--- a/apiens/tools/graphql/resolver/resolver_marker.py
+++ b/apiens/tools/graphql/resolver/resolver_marker.py
@@ -71,7 +71,11 @@ def assert_no_unmarked_resolvers(schema: graphql.GraphQLSchema, *,
     unmarked_resolvers = [
         f"{field.resolve.__qualname__} (module: {field.resolve.__module__})"  # type: ignore[union-attr]
         for field in find_fields_with_unmarked_resolvers(schema)
-        if _get_resolver_module_name(field.resolve) not in ignore_modules and _get_resolver_func(field.resolve) not in ignore_resolvers
+        if (
+            field.resolve is not None and 
+            _get_resolver_module_name(field.resolve) not in ignore_modules and 
+            _get_resolver_func(field.resolve) not in ignore_resolvers
+        )
     ]
     if not unmarked_resolvers:
         return

--- a/apiens/tools/graphql/resolver/resolver_marker.py
+++ b/apiens/tools/graphql/resolver/resolver_marker.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import asyncio
 import functools
 import graphql
-import inspect
 from enum import Enum
 from typing import Any, TypeVar, Optional
 from collections import abc

--- a/apiens/tools/graphql/resolver/resolver_marker.py
+++ b/apiens/tools/graphql/resolver/resolver_marker.py
@@ -60,7 +60,10 @@ def resolves_async(function: AFT) -> AFT:
 BUILTIN_GRAPHQL_MODULES = frozenset((
     'graphql.execution.execute',  # default resolver
     'graphql.type.introspection',  # built-in types
-    'ariadne.resolvers',  # fallback resolvers
+    'ariadne.resolvers',  # lib: ariadne
+    'graphene.types.resolver',  # lib: graphene
+    'graphene_sqlalchemy.resolvers', # lib: graphene-sqlalchemy
+    'graphene_sqlalchemy.fields', # lib: graphene-sqlalchemy
 ))
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "apiens"
-version = "2.0.0"
+version = "2.0.1"
 description = ""
 authors = ["Mark Vartanyan <kolypto@gmail.com>"]
 repository = 'https://github.com/kolypto/py-apiens'

--- a/tests/testing/test_model_match.py
+++ b/tests/testing/test_model_match.py
@@ -171,12 +171,10 @@ def test_transform():
     except ImportError:
         pass
     else:
-        upper_case_rewrite = jessiql.rewrite.Transform(str.upper, str.lower)
-        settings = jessiql.QuerySettings(
-            rewriter=jessiql.rewrite.RewriteSAModel(upper_case_rewrite, Model=User),
-        )
+        user_match = model_match.match(User)
+        rewriter = jessiql.query_object.rewrite.map_sqlalchemy_model(User, db_to_api=str.upper)
 
-        assert model_match.jessiql_rewrite_api_to_db(user_match, settings.rewriter, context=jessiql.rewrite.FieldContext.SELECT).jsonable() == {
+        assert model_match.jessiql_rewrite_db_to_api(user_match, rewriter).jsonable() == {
             'fields': {
                 'ID': DictMatch({'name': 'ID'}),
                 'LOGIN': DictMatch({'name': 'LOGIN'}),

--- a/tests/tools_graphql/test_resolver_marker.py
+++ b/tests/tools_graphql/test_resolver_marker.py
@@ -1,3 +1,4 @@
+from functools import partial
 import graphql
 import ariadne
 import ariadne.asgi
@@ -52,6 +53,9 @@ def test_resolver_markers():
     def resolve_object(_, info: graphql.GraphQLResolveInfo):
         return {'a': 1, 'b': 2, 'c': 3}
 
+    # Test partial() resolvers because they may obstruct access to the decorator
+    QueryType.set_field('another_object', partial(resolve_object))
+
     # language=graphql
     schema = ariadne.make_executable_schema('''
     type Query {
@@ -59,6 +63,7 @@ def test_resolver_markers():
         threaded: String!
         nonblocking: String!
         object: ABC!
+        another_object: ABC
     }
 
     type ABC {

--- a/tests/tools_graphql/test_resolver_marker.py
+++ b/tests/tools_graphql/test_resolver_marker.py
@@ -1,18 +1,29 @@
-from functools import partial
+import pytest
 import graphql
 import ariadne
 import ariadne.asgi
+from functools import partial
 
 from apiens.tools.ariadne.testing.test_client import AriadneTestClient
-from apiens.tools.graphql.resolver.resolver_marker import resolves_nonblocking, resolves_in_threadpool, assert_no_unmarked_resolvers
+from apiens.tools.graphql.resolver.resolver_marker import resolves_in_threadpool, resolves_nonblocking, assert_no_unmarked_resolvers
 
 
-def test_resolver_markers():
+@pytest.mark.parametrize('fail', (False, True))
+def test_resolver_markers(fail: bool):
     def main(c: AriadneTestClient):
         # === Test: run validation to make sure all resolvers are fine
-        assert_no_unmarked_resolvers(schema)
+        if not fail:
+            assert_no_unmarked_resolvers(schema)
+        else:
+            with pytest.raises(AssertionError) as e:
+                assert_no_unmarked_resolvers(schema)
+            assert 'resolve_threaded' in str(e.value)
+            assert 'resolve_nonblocking' in str(e.value)
+            assert 'resolve_object' in str(e.value)
+            assert 'resolve_async' not in str(e.value)
+            assert 'ariadne' not in str(e.value)
 
-        # === Test: GraphQL Test Client
+        # === Test: everything works
         res = c.execute('query { async threaded nonblocking object { a b c } }')
         assert res.successful().data == {
             'async': 'async',
@@ -25,6 +36,16 @@ def test_resolver_markers():
             },
         }
 
+    # Decorators and no-op decorators.
+    # If we expect to fail, decorators should do nothing
+    if fail:
+        resolves_in_threadpool = resolves_nonblocking = lambda f: f
+    else:
+        from apiens.tools.graphql.resolver.resolver_marker import (
+            resolves_nonblocking, resolves_in_threadpool
+        )
+
+
     # Resolvers:
     # Three types:
     # 1. async function
@@ -33,7 +54,7 @@ def test_resolver_markers():
     QueryType = ariadne.QueryType()
 
     @QueryType.field('async')
-    async def resolve_async(_, info: graphql.GraphQLResolveInfo):
+    async def resolve_async(_, info: graphql.GraphQLResolveInfo):  # async functions don't need to be decorated
         return 'async'
 
     @QueryType.field('threaded')

--- a/tests/tools_web/test_jwt_token.py
+++ b/tests/tools_web/test_jwt_token.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
     Fails with Pydantic 1.7.4: says, APIAccessToken has no attribute 'SECRET_KEY'.
     Looks like this version has some issues with class-level attributes.
 """)
-@pytest.mark.skipif(platform.python_version() == '3.10.5' and pd.VERSION in ('1.7.4', '1.8', '1.8.1', '1.8.2'), reason="""
+@pytest.mark.skipif(platform.python_version() == '3.10.6' and pd.VERSION in ('1.7.4', '1.8', '1.8.1', '1.8.2'), reason="""
     Fails with newer Python 3.10 versions and older Pydantic versions: "
     complains that "ClassVar" is not a valid field annotation. That's a bug in Python.
 """)
@@ -64,4 +64,5 @@ def test_jwt_token():
 
     # Go
     main()
+    
     


### PR DESCRIPTION
It's a fix to assert_no_unmarked_resolvers() and its unit-test:
it failed on `partial()` objects because they have no `__module__` and no `__qualname__`