### PR TITLE
Unit-test helper for subscriptions

### DIFF
--- a/apiens/tools/graphql/resolver/resolver_marker.py
+++ b/apiens/tools/graphql/resolver/resolver_marker.py
@@ -63,6 +63,7 @@ BUILTIN_GRAPHQL_MODULES = frozenset((
     'graphene.types.resolver',  # lib: graphene
     'graphene_sqlalchemy.resolvers', # lib: graphene-sqlalchemy
     'graphene_sqlalchemy.fields', # lib: graphene-sqlalchemy
+    'graphene_sqlalchemy.types', # lib: graphene-sqlalchemy
 ))
 
 

--- a/apiens/tools/graphql/resolver/resolver_marker.py
+++ b/apiens/tools/graphql/resolver/resolver_marker.py
@@ -61,6 +61,7 @@ BUILTIN_GRAPHQL_MODULES = frozenset((
     'graphql.type.introspection',  # built-in types
     'ariadne.resolvers',  # lib: ariadne
     'graphene.types.resolver',  # lib: graphene
+    'graphene.types.schema',  # lib: graphene
     'graphene_sqlalchemy.resolvers', # lib: graphene-sqlalchemy
     'graphene_sqlalchemy.fields', # lib: graphene-sqlalchemy
     'graphene_sqlalchemy.types', # lib: graphene-sqlalchemy

--- a/apiens/tools/graphql/testing/query.py
+++ b/apiens/tools/graphql/testing/query.py
@@ -82,7 +82,11 @@ class GraphQLResult(Generic[ContextT]):
         return self
 
     def __getitem__(self, name):
-        """ Get a result field, assuming that there were no errors """
+        """ Get a result field, assuming that there were no errors 
+        
+        Note: it will re-raise the original GraphQL errors if you attempt to access fields while there are errors!
+        To access fields anyway, use `.data`.
+        """
         self.successful()
         return self.data[name]
 
@@ -102,7 +106,11 @@ class GraphQLResult(Generic[ContextT]):
         Usage:
             assert res.app_error_name == 'E_AUTH_REQUIRED'
         """
-        return self.app_error['name']
+        # Try to get it from the exception object first
+        if exception := self.original_error:
+            return exception.name   # type: ignore[attr-defined]
+        else:
+            return self.app_error['name']
 
     @property
     def graphql_error(self) -> GraphqlResponseErrorObject:

--- a/apiens/tools/graphql/testing/query.py
+++ b/apiens/tools/graphql/testing/query.py
@@ -82,12 +82,14 @@ class GraphQLResult(Generic[ContextT]):
         return self
 
     def __getitem__(self, name):
-        """ Get a result field, assuming that there were no errors 
-        
-        Note: it will re-raise the original GraphQL errors if you attempt to access fields while there are errors!
-        To access fields anyway, use `.data`.
+        """ Get a key from the result dict, but fail if there were any errors.
+
+        This method allows you to access result dict keys conveniently:
+        >>> res['fieldName']
+        But you can only legitimately do this if there were no errors. 
+        If there was an error, it would fail.
         """
-        self.successful()
+        self.raise_errors()
         return self.data[name]
 
     @property

--- a/apiens/tools/graphql/testing/query.py
+++ b/apiens/tools/graphql/testing/query.py
@@ -23,7 +23,7 @@ def graphql_query_sync(schema: graphql.GraphQLSchema, query: str, context_value:
     return GraphQLResult(
         res.formatted,  # type: ignore[arg-type]
         context=context_value,
-        exceptions=res.errors,
+        exceptions=list(res.errors or ()),
     )
 
 async def graphql_query_async(schema: graphql.GraphQLSchema, query: str, context_value: Any = None, /, operation_name: str = None, **variable_values) -> GraphQLResult:
@@ -38,7 +38,7 @@ async def graphql_query_async(schema: graphql.GraphQLSchema, query: str, context
     return GraphQLResult(
         res.formatted,  # type: ignore[arg-type]
         context=context_value,
-        exceptions=res.errors,
+        exceptions=list(res.errors or ()),
     )
 
 
@@ -67,7 +67,7 @@ class GraphQLResult(Generic[ContextT]):
 
     def __init__(self, response: GraphQLResponseDict, context: ContextT = None, exceptions: abc.Iterable[graphql.GraphQLError] = None):
         self.data = response.get('data', None)
-        self.errors = response.get('errors', [])
+        self.errors = list(response.get('errors') or ())
         self.exceptions = list(exceptions or ())
         self.context = context
 

--- a/apiens/tools/graphql/testing/test_client.py
+++ b/apiens/tools/graphql/testing/test_client.py
@@ -19,9 +19,14 @@ class GraphQLTestClient:
     # Execute queries
 
     def execute(self, query: str, /, **variables) -> GraphQLResult[ContextT]:
-        """ Execute a GraphQL query, with async resolver support """
+        """ Execute a GraphQL query, in sync mode, but with async resolver support """
         with self.init_context_sync() as context_value:
             return self.execute_operation(query, context_value, **variables)
+
+    async def execute_async(self, query: str, /, **variables) -> GraphQLResult[ContextT]:
+        """ Execute a GraphQL query in async mode """
+        async with self.init_context_async() as context_value:
+            return await self.execute_async_operation(query, context_value, **variables)
 
     def execute_sync(self, query: str, /, **variables) -> GraphQLResult[ContextT]:
         """ Execute a GraphQL query in sync mode """
@@ -88,15 +93,20 @@ class GraphQLTestClient:
         """
         return graphql_query_sync(self.schema, query, context_value, operation_name, **variables)
 
-    async def execute_subscription(self, query: str, context_value: Any = None, **variables) -> abc.AsyncIterator[GraphQLResult[ContextT]]:
+    async def execute_subscription(self, query: str, context_value: Any = None, **variables) -> abc.AsyncIterator[Optional[dict[str, Any]]]:
         """ Execute a GraphQL subscription """
-        res = await graphql.subscribe(
+        document = graphql.parse(query)
+        gen = await graphql.subscribe(
             self.schema,
-            query,  # type: ignore[arg-type]
+            document,
             context_value=context_value,
             variable_values=variables,
         )
-        # TODO: implement
-        raise NotImplementedError
+        if isinstance(gen, graphql.ExecutionResult):
+            GraphQLResult(gen.formatted, context_value, exceptions=gen.errors).raise_errors()  # type: ignore[arg-type]
+        else:
+            async for res in gen:
+                assert not res.errors
+                yield res.data
 
     #endregion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "apiens"
-version = "2.0.2"
+version = "2.0.4"
 description = ""
 authors = ["Mark Vartanyan <kolypto@gmail.com>"]
 repository = 'https://github.com/kolypto/py-apiens'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "apiens"
-version = "2.0.1"
+version = "2.0.2"
 description = ""
 authors = ["Mark Vartanyan <kolypto@gmail.com>"]
 repository = 'https://github.com/kolypto/py-apiens'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ graphql-core = {version = ">= 3.1.0", optional = true}
 ariadne = {version = ">= 0.13.0", optional = true}
 pytz = {version = ">= 2020.1", optional = true}
 python-jose = {version = ">= 1.0.0", optional = true}
+python-dotnev = {version = ">= 0.15.0", optional = true}
 
 [tool.poetry.dev-dependencies]
 nox = ">=2020.8.22"
@@ -34,6 +35,7 @@ types-psycopg2 = ">=2.9.6"
 pytz = ">= 2022.1"
 pytest-asyncio = ">= 0.18.3"
 python-jose = ">= 3.2.0"
+python-dotenv = "^0.20.0"
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ graphql-core = {version = ">= 3.1.0", optional = true}
 ariadne = {version = ">= 0.13.0", optional = true}
 pytz = {version = ">= 2020.1", optional = true}
 python-jose = {version = ">= 1.0.0", optional = true}
-python-dotnev = {version = ">= 0.15.0", optional = true}
+python-dotenv = {version = ">= 0.15.0", optional = true}
 
 [tool.poetry.dev-dependencies]
 nox = ">=2020.8.22"
@@ -35,7 +35,7 @@ types-psycopg2 = ">=2.9.6"
 pytz = ">= 2022.1"
 pytest-asyncio = ">= 0.18.3"
 python-jose = ">= 3.2.0"
-python-dotenv = "^0.20.0"
+python-dotenv = ">= 0.20.0"
 
 
 [build-system]

--- a/tests/tools_graphql/test_graphql_testing.py
+++ b/tests/tools_graphql/test_graphql_testing.py
@@ -1,0 +1,145 @@
+import anyio
+import pytest
+import graphql
+
+from apiens.tools.graphql.testing.test_client import GraphQLTestClient
+from apiens.testing.object_match import DictMatch
+from apiens.error import exc
+
+
+@pytest.mark.asyncio
+async def test_graphql_test_client():
+    """ Testing the test client. Recursively :) """
+    async def main():
+        q_ok = 'query { ok }'
+        q_fail = 'query { fail }'
+        q_app_fail = 'query { app_fail }'
+        q_count = 'subscription { count }'
+
+        # === Test: sync query
+        with GraphQLTestClient(schema) as c:
+            # q_ok
+            res = c.execute_sync(q_ok).successful()
+            assert res.ok
+            assert res.data == {'ok': 'ok'}
+            assert res.errors == []
+            assert res.exceptions == []
+            assert res['ok'] == 'ok'
+
+            # q_fail
+            res = c.execute_sync(q_fail)
+            assert not res.ok
+            assert res.data == {'fail': None}
+            assert res.errors == [DictMatch(
+                message='Bad',
+                path=['fail'],
+            )]
+            assert isinstance(res.exceptions[0], graphql.GraphQLError)
+            assert res.exceptions[0].message == 'Bad'
+            assert isinstance(res.exceptions[0].original_error, ValueError)
+            assert res.exceptions[0].args == ('Bad',)
+
+            with pytest.raises(ValueError):
+                assert res['fail']
+            with pytest.raises(ValueError):
+                res.raise_errors()
+
+            # q_app_fail
+            res = c.execute_sync(q_app_fail)
+            assert res.data == {'app_fail': None}
+            assert res.errors == [DictMatch(
+                message='Bad',
+                path=['app_fail'],
+            )]
+            assert isinstance(res.exceptions[0], graphql.GraphQLError)
+            assert res.exceptions[0].message == 'Bad'
+            assert isinstance(res.exceptions[0].original_error, exc.E_API_ARGUMENT)
+            assert res.exceptions[0].original_error.name == 'E_API_ARGUMENT'
+            
+            with pytest.raises(exc.E_API_ARGUMENT):
+                assert res['fail']
+            with pytest.raises(exc.E_API_ARGUMENT):
+                res.raise_errors()
+            
+            assert res.app_error_name == 'E_API_ARGUMENT'
+            assert res.graphql_error == res.exceptions[0]
+            assert res.original_error == res.exceptions[0].original_error
+
+
+        # === Test: async query
+        with GraphQLTestClient(schema) as c:
+            res = await c.execute_async(q_ok)
+            assert res['ok'] == 'ok'
+
+        # === Test: query
+        with GraphQLTestClient(schema) as c:
+            # Run it in a thread because it uses asyncio.run()
+            res = await anyio.to_thread.run_sync(c.execute, q_ok)
+            
+            assert res['ok'] == 'ok'
+
+        # === Test: subscription
+        with GraphQLTestClient(schema) as c:
+            res = c.subscribe(q_count)
+            results = [item async for item in res]
+            assert results == [
+                {'count': 1},
+                {'count': 2},
+                {'count': 3},
+            ]
+
+    # Resolvers
+
+    def resolve_ok(_, info):
+        return 'ok'
+
+    def resolve_fail(_, info):
+        raise ValueError('Bad')
+    
+    def resolve_app_fail(_, info):
+        raise exc.E_API_ARGUMENT('Bad', 'Tryagain', name='arg')
+
+    async def subscribe_count(_, info):
+        yield {'count': 1}
+        yield {'count': 2}
+        yield {'count': 3}
+
+    # GraphQL objects
+    Query = graphql.GraphQLObjectType('Query', fields={
+        # A field that reports success
+        'ok': graphql.GraphQLField(
+            graphql.GraphQLString, 
+            resolve=resolve_ok,
+        ),
+        # A field that returns a Python exception
+        'fail': graphql.GraphQLField(
+            graphql.GraphQLString,
+            resolve=resolve_fail,
+        ),
+        # A field that returns Application Exception
+        'app_fail': graphql.GraphQLField(
+            graphql.GraphQLString,
+            resolve=resolve_app_fail,
+        ),
+    })
+
+    Subscription = graphql.GraphQLObjectType('Subscription', fields={
+        # A field for testing subscriptions
+        'count': graphql.GraphQLField(
+            graphql.GraphQLInt,
+            subscribe=subscribe_count,
+        ),
+        'count2': graphql.GraphQLField(
+            graphql.GraphQLInt,
+            subscribe=subscribe_count,
+        ),
+    })
+
+    # GraphQL Schema
+    schema = graphql.GraphQLSchema(
+        query=Query,
+        subscription=Subscription,
+    )
+
+    # Go
+    await main()

--- a/tests/tools_settings/test_mixins.py
+++ b/tests/tools_settings/test_mixins.py
@@ -1,0 +1,11 @@
+from apiens.tools.settings.mixins import CorsMixin
+
+def test_cors_origins():
+    # NOTE: CorsMixin actually alters the environment in order to support JSON arrays.
+    # After the value is patched, it should still be acceptable to CorsMixin.
+
+    # Original, unpatched string
+    settings = CorsMixin(CORS_ORIGINS='http://localhost,http://localhost:8080')
+
+    # Patched string
+    settings = CorsMixin(CORS_ORIGINS='["http://localhost", "http://localhost:8080"]')


### PR DESCRIPTION
Includes a new method for the GraphQL unit-test runner that handles realtime subscriptions.

Also, ignored a few more Graphene modules in resolver_marker: because we don't want to decorate built-in modules, do we? :) 