### PR TITLE
Use importlib to define __version__

### DIFF
--- a/apiens/__init__.py
+++ b/apiens/__init__.py
@@ -1,1 +1,5 @@
-__version__ = __import__('pkg_resources').get_distribution('apiens').version
+from importlib.metadata import version
+
+__version__ = version('apiens')
+
+del version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "apiens"
-version = "2.0.6"
+version = "2.0.7"
 description = ""
 authors = ["Mark Vartanyan <kolypto@gmail.com>"]
 repository = 'https://github.com/dignio/kolypto-apiens'


### PR DESCRIPTION
The pkg_resources package from setuptools has been superseded by importlib. Having a dependency of setuptools in this library means that clients of this library also need setuptools, which can be problematic.