### PR TITLE
Use httpx over requests

### DIFF
--- a/apiens/tools/graphql/testing/test_client_api.py
+++ b/apiens/tools/graphql/testing/test_client_api.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import requests  # type: ignore[import]
+import httpx  # type: ignore[import]
 import starlette.testclient
 from dataclasses import dataclass
 from collections import abc
@@ -46,14 +46,14 @@ class GraphQLClientMixin:
         res = self.graphql_sync_request(query, **variables)
 
         # It must be a 200 OK even in case of an error response
-        assert res.response.ok, f'Bad response code: {res.response.status_code}: {res.response.content}'
+        assert res.response.is_success, f'Bad response code: {res.response.status_code}: {res.response.content}'
 
         # Done
         return res
 
     def graphql_sync_request(self, query: str, /, **variables) -> GraphQLResponse:
         """ Make a GraphQL HTTP request and get a response """
-        res: requests.Response = self.post(  # type: ignore[attr-defined]
+        res: httpx.Response = self.post(  # type: ignore[attr-defined]
             url=self.GRAPHQL_ENDPOINT,
             json=dict(
                 query=query,
@@ -116,8 +116,8 @@ class GraphQLClientMixin:
 class GraphQLResponse(GraphQLResult):
     """ GraphQL result + response object """
     # The original HTTP request object
-    response: requests.Response
+    response: httpx.Response
 
-    def __init__(self, response: requests.Response):
+    def __init__(self, response: httpx.Response):
         self.response = response
         super().__init__(response.json())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ include = ["apiens/py.typed"]
 python = "^3.9"
 docstring-parser = {version = ">= 0.10", optional = true}
 pydantic = {version = ">= 1.7", optional = true}
-fastapi = {version = ">= 0.69.0", optional = true}
+fastapi = {version = ">= 0.92.0", optional = true}
 SQLAlchemy = {version = ">= 1.3.1", optional = true}
 graphql-core = {version = ">= 3.1.0", optional = true}
 ariadne = {version = ">= 0.13.0", optional = true}
@@ -26,7 +26,7 @@ mypy = ">=0.910"
 docstring-parser = ">=0.10"
 requests = ">=2.26.0"
 pydantic = ">=1.7.0"
-fastapi = ">=0.59.0"
+fastapi = ">=0.92.0"
 graphql-core = ">=3.0.0"
 ariadne = ">=0.13.0"
 SQLAlchemy = {extras = ["mypy"], version = ">= 1.3.1"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ pytz = ">= 2022.1"
 pytest-asyncio = ">= 0.18.3"
 python-jose = ">= 3.2.0"
 python-dotenv = ">= 0.20.0"
+httpx = "^0.23.3"
 
 
 [build-system]


### PR DESCRIPTION
Starlette has in version 0.21.0 changed from using the `requests` library to use `httpx` for its test client.
Newest FastAPI version depends on a newer version of `Starlette` that has this new dependency.

The changes here are done to fix a security issue in an older version of Starlette, forcing Prevent to
use a newer version of FastAPI, which depends on a newer version of Starlette.

https://github.com/dignio/v2-server/security/dependabot/80